### PR TITLE
Add \ to cipher reg path

### DIFF
--- a/DSCResources/cCipher/cCipher.psm1
+++ b/DSCResources/cCipher/cCipher.psm1
@@ -33,7 +33,7 @@ function Get-TargetResource
         $Ensure
     )
 
-    $RootKey = 'HKLM:SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers'
+    $RootKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers'
     $Key = $RootKey + "\" + $cipher 
     if(Test-SchannelItem -itemKey $Key -enable $true)
     {
@@ -69,7 +69,7 @@ function Set-TargetResource
         $Ensure
     )
 
-    $RootKey = 'HKLM:SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers'
+    $RootKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers'
     $Key = $RootKey + "\" + $cipher 
 
     if($Ensure -eq "Present")
@@ -102,7 +102,7 @@ function Test-TargetResource
         [System.String]
         $Ensure
     )
-    $RootKey = 'HKLM:SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers'
+    $RootKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers'
     $Key = $RootKey + "\" + $cipher 
     $currentCipher = Get-TargetResource @PSBoundParameters
     $Compliant = $false


### PR DESCRIPTION
The \ after hklm is missing in cipher but present in the other resources